### PR TITLE
Fix issue in patch function

### DIFF
--- a/go.js
+++ b/go.js
@@ -163,7 +163,7 @@ class Handler {
 
   async patch({ offset, blob, size, filename }) {
     const output = await this.output(filename)
-    const fd = await fs.open(output, 'a')
+    const fd = await fs.open(output, 'r+')
     let buf = null
     if (blob) {
       buf = this.blob(blob).done()


### PR DESCRIPTION
While analysing decrypted binaries with bagbak, I found that the cryptid was not being set to zero. After debugging I found that the patching of the original binary with the decrypted content and the setting of the cryptid to zero are failing. After more debugging I found out that the: https://github.com/ChiChou/bagbak/blob/46ab93abe4bfedd8a19df193a2d0658f0d2ff74a/go.js#L178 although it has an offset, the contents are being appended to end of the file instead of writing them at the specified offset.

By changing the file sytem flag at: https://github.com/ChiChou/bagbak/blob/46ab93abe4bfedd8a19df193a2d0658f0d2ff74a/go.js#L166 from **'a'** to **'r+'** - read and write I was able to have the desired behaviour.

I've tested this in an Ubuntu 18.04.3 LTS and latest Kali Linux with:
- node - v12.14.0 LTS
- npm - v6.13.4