### PR TITLE
fix: use `fs.rm` over `fs.rmdir`

### DIFF
--- a/go.js
+++ b/go.js
@@ -416,7 +416,7 @@ async function main() {
 
       const ipa = path.join(program.output, app + '.ipa')
       await fs.rename(path.join(program.output, app + '.zip'), ipa)
-      await fs.rmdir(cwd, { recursive: true })
+      await fs.rm(cwd, { recursive: true })
 
       console.log(`archive: ${chalk.blue(ipa)}`)
       console.log(`contents: ${chalk.green(cwd)}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bagbak",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "description": "Dump iOS app from a jailbroken device, based on frida.re",
   "main": "go.js",
   "scripts": {


### PR DESCRIPTION
\+ bump version to `2.6.5`