### PR TITLE
feat: quit with exit code on error

### DIFF
--- a/go.js
+++ b/go.js
@@ -431,5 +431,5 @@ async function main() {
 main().catch(e => {
   console.error(chalk.red('FATAL ERROR'))
   console.error(e)
-  process.exit()
+  process.exit(1)
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bagbak",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "Dump iOS app from a jailbroken device, based on frida.re",
   "main": "go.js",
   "scripts": {


### PR DESCRIPTION
if bagbak is being run inside a script, exiting with exit code 1 will make it easier to tell if the dumping process succeeded or not.